### PR TITLE
Use target commit to link to the line number used in the blame

### DIFF
--- a/TestCoverageReport/CreateReport.cs
+++ b/TestCoverageReport/CreateReport.cs
@@ -65,6 +65,7 @@ namespace TestCoverageReport
 
                     foreach (FileReportLine line in report.Files[file])
                     {
+                        line.TargetCommitId = report.TargetCommitId;
                         renderer.WriteFileLine(line);
                     }
 

--- a/TestCoverageReport/Model/FileReportLine.cs
+++ b/TestCoverageReport/Model/FileReportLine.cs
@@ -7,6 +7,7 @@
         public int LineNumber { get; set; }
         public string LineContents { get; set; }
         public bool Ignored { get; set; }
+        public string TargetCommitId { get; set; }
 
         public string GetShortCommitId()
         {

--- a/TestCoverageReport/Renderers/HtmlRenderer.cs
+++ b/TestCoverageReport/Renderers/HtmlRenderer.cs
@@ -89,12 +89,14 @@ namespace TestCoverageReport
             this.writer.WriteLine($@"
     <tr class=""{tr_class}"">
 		<td class=""commit-id"">
-            <a href=""https://github.com/git/git/tree/{line.CommitId}/{line.FileName}#L{line.LineNumber}"">
+            <a href=""https://github.com/git/git/commit/{line.CommitId}"">
                 {line.GetShortCommitId()}
             </a>
         </td>
         <td class=""line-number"">
-			{line.LineNumber}
+            <a href=""https://github.com/git/git/tree/{line.TargetCommitId}/{line.FileName}#L{line.LineNumber}"">
+			    {line.LineNumber}
+            </a>
 		</td>
 		<td class=""code"">
 			{Sanitize(line.LineContents)}


### PR DESCRIPTION
The blame output uses line numbers from the target commit, but when we link to the commit with the diff, the lines may be different. So, use two links in the HTML report:

1. Link to the commit in question, so you can get context for the change.
2. Link to the line in question on the target commit id, to get context in the full version.