### PR TITLE
connect.c: Ignore not tested UNC path with file:// scheme

### DIFF
--- a/ignored/connect.c
+++ b/ignored/connect.c
@@ -1,0 +1,1 @@
+921:path = host - 2; /* include the leading "//" */


### PR DESCRIPTION
The URL git clone file://server/share/repo makes only sense on Windows.
Unix/Linux/POSIX systems use always file:///pathto/repo.
Because of that, we don't have a test case for non-Windows system.