### PR TITLE
Update ignored logic to include an exact line ANYWHERE

### DIFF
--- a/TestCoverageReport/Collect.cs
+++ b/TestCoverageReport/Collect.cs
@@ -121,13 +121,35 @@ namespace TestCoverageReport
                 return reportLines;
             }
 
+            List<string> ignoredPhrases = new List<string>()
+            {
+                "BUG(",
+                "error(",
+                "die(",
+                "warning(",
+                "advise(",
+                "usage_with_options(",
+            };
+
             foreach (FileReportLine line in reportLines)
             {
-                string ignoreLine = $"{line.LineNumber}:{line.LineContents.Trim()}";
+                string ignoreLine = line.LineContents.Trim();
+                string ignoreLineWithNum = $"{line.LineNumber}:{ignoreLine}";
 
-                if (ignoredLines.Contains(ignoreLine))
+                if (ignoredLines.Contains(ignoreLine) ||
+                    ignoredLines.Contains(ignoreLineWithNum))
                 {
                     line.Ignored = true;
+                    continue;
+                }
+
+                foreach (string phrase in ignoredPhrases)
+                {
+                    if (line.LineContents.IndexOf(phrase) >= 0)
+                    {
+                        line.Ignored = true;
+                        break;
+                    }
                 }
             }
 

--- a/ignored/connect.c
+++ b/ignored/connect.c
@@ -1,0 +1,1 @@
+path = host - 2; /* include the leading "//" */

--- a/ignored/pack-bitmap.c
+++ b/ignored/pack-bitmap.c
@@ -1,0 +1,1 @@
+return; /* broken packfile, punt */

--- a/ignored/packfile.c
+++ b/ignored/packfile.c
@@ -1,0 +1,1 @@
+return; /* broken packfile, punt */


### PR DESCRIPTION
Some lines are so specific that they can be ignored by an exact line
contents match, not just a line number AND contents match. Allow these
to exist.

Also, automatically ignore lines that include error case markers, such
as:

 * advise(, die(, error(, and warning(
 * BUG(
 * usage_with_options(

Makes #34 obsolete.